### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make


### PR DESCRIPTION
GitHub can run builds on every commit and/or pull request, free for open source projects.  Perhaps I failed to account for some dependencies when running `make`; looking at https://github.com/ddugovic/Minic/actions/runs/309733686 I am not sure.